### PR TITLE
Fix async loop in serverless sub-entities handler

### DIFF
--- a/packages/twenty-server/src/modules/workflow/common/workspace-services/workflow-common.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/common/workspace-services/workflow-common.workspace-service.ts
@@ -199,32 +199,42 @@ export class WorkflowCommonWorkspaceService {
       withDeleted: true,
     });
 
-    workflowVersions.forEach((workflowVersion) => {
-      workflowVersion.steps?.forEach(async (step) => {
-        if (step.type === WorkflowActionType.CODE) {
-          switch (operation) {
-            case 'delete':
-              await this.serverlessFunctionService.deleteOneServerlessFunction({
-                id: step.settings.input.serverlessFunctionId,
-                workspaceId,
-                softDelete: true,
-              });
-              break;
-            case 'restore':
-              await this.serverlessFunctionService.restoreOneServerlessFunction(
-                step.settings.input.serverlessFunctionId,
-              );
-              break;
-            case 'destroy':
-              await this.serverlessFunctionService.deleteOneServerlessFunction({
-                id: step.settings.input.serverlessFunctionId,
-                workspaceId,
-                softDelete: false,
-              });
-              break;
-          }
+    await Promise.all(
+      workflowVersions.map(async (workflowVersion) => {
+        if (!workflowVersion.steps?.length) {
+          return;
         }
-      });
-    });
+
+        await Promise.all(
+          workflowVersion.steps.map(async (step) => {
+            if (step.type !== WorkflowActionType.CODE) {
+              return;
+            }
+
+            switch (operation) {
+              case 'delete':
+                await this.serverlessFunctionService.deleteOneServerlessFunction({
+                  id: step.settings.input.serverlessFunctionId,
+                  workspaceId,
+                  softDelete: true,
+                });
+                break;
+              case 'restore':
+                await this.serverlessFunctionService.restoreOneServerlessFunction(
+                  step.settings.input.serverlessFunctionId,
+                );
+                break;
+              case 'destroy':
+                await this.serverlessFunctionService.deleteOneServerlessFunction({
+                  id: step.settings.input.serverlessFunctionId,
+                  workspaceId,
+                  softDelete: false,
+                });
+                break;
+            }
+          }),
+        );
+      }),
+    );
   }
 }


### PR DESCRIPTION
## Summary
- properly wait for async serverless function operations

## Testing
- `yarn install --immutable --mode=skip-build` *(fails: couldn't complete in time)*

------
https://chatgpt.com/codex/tasks/task_e_68408e13b8b4832f888ce2a086cffd14