### PR TITLE
Add LLM based lead generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Below are a few features we have implemented to date:
 + [See rich notes tasks displayed in a timeline](#see-rich-notes-tasks-displayed-in-a-timeline)
 + [Create tasks on records](#create-tasks-on-records)
 + [Navigate quickly through the app using keyboard shortcuts and search](#navigate-quickly-through-the-app-using-keyboard-shortcuts-and-search)
++ [Generate leads from past customers via LLM](#generate-leads-from-past-customers-via-llm)
 
 
 ## Add, filter, sort, edit, and track customers:
@@ -125,6 +126,10 @@ Below are a few features we have implemented to date:
       <img src="./packages/twenty-docs/static/img/keyboard-dark.png" alt="Keyboard shortcuts" />
     </picture>
 </p>
+## Generate leads from past customers via LLM:
+
+Twenty now analyzes customer notes with GPT-4o to surface repeat customers and upsell opportunities.
+
 
 ## Connect your CRM to all your tools through our APIs and Webhooks.
 

--- a/packages/twenty-server/src/modules/lead-generation/lead-generation.module.ts
+++ b/packages/twenty-server/src/modules/lead-generation/lead-generation.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+
+import { LeadGenerationService } from './lead-generation.service';
+
+@Module({
+  providers: [LeadGenerationService],
+  exports: [LeadGenerationService],
+})
+export class LeadGenerationModule {}

--- a/packages/twenty-server/src/modules/lead-generation/lead-generation.service.ts
+++ b/packages/twenty-server/src/modules/lead-generation/lead-generation.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@nestjs/common';
+
+import { LLMChatModelService } from 'src/engine/core-modules/llm-chat-model/llm-chat-model.service';
+
+export interface LeadSuggestion {
+  customer: string;
+  reason: string;
+}
+
+@Injectable()
+export class LeadGenerationService {
+  constructor(private readonly llmChatModelService: LLMChatModelService) {}
+
+  async generateLeads(notes: string[]): Promise<LeadSuggestion[]> {
+    const prompt = `Analyze the following CRM notes and past interactions. Identify potential repeat customers or upsell opportunities and return them as a JSON array named leads where each entry has \"customer\" and \"reason\" fields.\n\n${notes.join('\n')}`;
+
+    const chatModel = this.llmChatModelService.getJSONChatModel();
+    const result = (await chatModel.invoke(prompt)) as { leads: LeadSuggestion[] };
+
+    return result.leads;
+  }
+}

--- a/packages/twenty-server/src/modules/modules.module.ts
+++ b/packages/twenty-server/src/modules/modules.module.ts
@@ -7,6 +7,7 @@ import { FavoriteModule } from 'src/modules/favorite/favorite.module';
 import { MessagingModule } from 'src/modules/messaging/messaging.module';
 import { ViewModule } from 'src/modules/view/view.module';
 import { WorkflowModule } from 'src/modules/workflow/workflow.module';
+import { LeadGenerationModule } from 'src/modules/lead-generation/lead-generation.module';
 
 @Module({
   imports: [
@@ -17,6 +18,7 @@ import { WorkflowModule } from 'src/modules/workflow/workflow.module';
     WorkflowModule,
     FavoriteFolderModule,
     FavoriteModule,
+    LeadGenerationModule,
   ],
   providers: [],
   exports: [],


### PR DESCRIPTION
## Summary
- add LeadGeneration module and service using GPT-4o
- expose the module via modules.module
- document lead generation in README

## Testing
- `yarn nx format:check` *(fails: package doesn't seem to be present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6840976a48ac832f954e83567f2a9b54