### PR TITLE
Add safari booking kanban docs

### DIFF
--- a/packages/twenty-website/src/content/user-guide/constants/UserGuideIndex.ts
+++ b/packages/twenty-website/src/content/user-guide/constants/UserGuideIndex.ts
@@ -12,6 +12,7 @@ export const USER_GUIDE_INDEX = {
       { fileName: 'views-sort-filter' },
       { fileName: 'table-views' },
       { fileName: 'kanban-views' },
+      { fileName: 'booking-kanban-pipeline' },
       { fileName: 'import-export-data' },
     ],
     Functions: [

--- a/packages/twenty-website/src/content/user-guide/objects/booking-kanban-pipeline.mdx
+++ b/packages/twenty-website/src/content/user-guide/objects/booking-kanban-pipeline.mdx
@@ -1,0 +1,32 @@
+---
+title: Safari Booking Kanban Pipeline
+info: Configure a Kanban board to track safari bookings from inquiry to completion.
+icon: IconChecklist
+image: /images/user-guide/kanban-views/kanban.png
+sectionInfo: Example pipeline using Kanban Views for safari bookings.
+---
+
+## Overview
+
+Kanban Views make it easy to manage safari bookings by visualizing each step in the process. Create a **Select Field** named `Stage` and add the following options in order:
+
+1. **Inquiry**
+2. **Deposit Paid**
+3. **Scheduled**
+4. **Completed**
+
+### Create the Kanban View
+
+1. Open your **Bookings** object and choose **Add view**.
+2. Select **Kanban** and pick the `Stage` field.
+3. Each booking record now appears as a card that you can drag between stages.
+
+### Customize Visible Fields
+
+To show or hide fields on the Kanban cards:
+
+1. Click **Options** in the top-right corner.
+2. Select **Fields** and toggle the information you want displayed.
+3. Rearrange fields by dragging them into the desired order.
+
+This setup keeps your safari booking pipeline clear and adaptable as your team works through inquiries, payments, scheduled trips and completed tours.


### PR DESCRIPTION
## Summary
- document how to manage a safari booking pipeline with Kanban views
- index the new guide in the user guide table of contents

## Testing
- `npx prettier packages/twenty-website/src/content/user-guide/constants/UserGuideIndex.ts packages/twenty-website/src/content/user-guide/objects/booking-kanban-pipeline.mdx --check`

------
https://chatgpt.com/codex/tasks/task_e_6840971de0cc832fb776974c98ee8034