### PR TITLE
Update tasks doc

### DIFF
--- a/packages/twenty-website/src/content/user-guide/functions/tasks.mdx
+++ b/packages/twenty-website/src/content/user-guide/functions/tasks.mdx
@@ -5,7 +5,7 @@ image: /images/user-guide/tasks/tasks_header.png
 sectionInfo: Learn how to connect Twenty to your other tools.
 ---
 
-Manage all tasks within your workspace using the **Tasks** feature. This guide will show you how to create and manage tasks, switch between upcoming and completed tasks, edit task details, and much more.
+Manage all tasks within your workspace using the **Tasks** feature. Use tasks to schedule reminders for client follow-ups or even plan upcoming safari preparations. This guide will show you how to create and manage tasks, switch between upcoming and completed tasks, edit task details, and much more.
 
 ## Creating Tasks
 
@@ -13,7 +13,9 @@ Creating tasks in Twenty is seamless. You can either:
 
 -  Go to the `Tasks`tab and press the `+` button at the top right of the page.
 -  Use the search function by pressing `cmd/ctrl + k`, then select 'Create task' from the list of quick actions.
--  Go to a `Record page` and press `+`at the top right of the page, or go to the Task tab and press the `Add Task`button. 
+-  Go to a `Record page` and press `+`at the top right of the page, or go to the Task tab and press the `Add Task`button.
+
+Once a task is completed, click the circle on its card to mark it `Done`.
 
 <div style={{padding:'70.59% 0 0 0', position:'relative', margin: '32px 0px 0px'}}>
   <iframe 


### PR DESCRIPTION
## Summary
- clarify that tasks can be used to schedule reminders and safari follow-ups
- note how to mark a task Done in the creation section

## Testing
- `yarn nx test twenty-website --skip-nx-cache` *(fails: package missing from lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_684096b35c0c832fa2fa9826f538ba26