### PR TITLE
Use keystatic date field

### DIFF
--- a/packages/twenty-website/keystatic.config.ts
+++ b/packages/twenty-website/keystatic.config.ts
@@ -58,8 +58,7 @@ export default config({
             },
           },
         }),
-        // TODO: Define the date with a normalized format
-        Date: fields.text({ label: 'Date' }),
+        Date: fields.date({ label: 'Date' }),
         content: fields.mdx({
           label: 'Content',
           options: {


### PR DESCRIPTION
## Summary
- update keystatic config to store release dates using `fields.date`

## Testing
- `npx prettier -w packages/twenty-website/keystatic.config.ts`

------
https://chatgpt.com/codex/tasks/task_e_68414938125c832f86e5688a41628886