### PR TITLE
Fix color scheme hook test

### DIFF
--- a/packages/twenty-front/src/modules/ui/theme/hooks/__tests__/useColorScheme.test.tsx
+++ b/packages/twenty-front/src/modules/ui/theme/hooks/__tests__/useColorScheme.test.tsx
@@ -1,5 +1,5 @@
 import { act, renderHook } from '@testing-library/react';
-import { RecoilRoot, useSetRecoilState } from 'recoil';
+import { RecoilRoot } from 'recoil';
 
 import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
 import { useColorScheme } from '@/ui/theme/hooks/useColorScheme';
@@ -28,23 +28,20 @@ const workspaceMember: Omit<
 };
 
 describe('useColorScheme', () => {
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <RecoilRoot
+      initializeState={({ set }) => {
+        set(currentWorkspaceMemberState, workspaceMember);
+      }}
+    >
+      {children}
+    </RecoilRoot>
+  );
+
   it('should update color scheme', async () => {
-    const { result } = renderHook(
-      () => {
-        const colorScheme = useColorScheme();
-
-        const setCurrentWorkspaceMember = useSetRecoilState(
-          currentWorkspaceMemberState,
-        );
-
-        setCurrentWorkspaceMember(workspaceMember);
-
-        return colorScheme;
-      },
-      {
-        wrapper: RecoilRoot,
-      },
-    );
+    const { result } = renderHook(() => useColorScheme(), {
+      wrapper: Wrapper,
+    });
 
     expect(result.current.colorScheme).toBe('System');
 
@@ -52,7 +49,6 @@ describe('useColorScheme', () => {
       await result.current.setColorScheme('Dark');
     });
 
-    // FIXME: For some reason, the color gets unset
-    // expect(result.current.colorScheme).toEqual('Dark');
+    expect(result.current.colorScheme).toEqual('Dark');
   });
 });


### PR DESCRIPTION
## Summary
- fix the useColorScheme test by initializing Recoil once and enabling the assertion

## Testing
- `npx jest packages/twenty-front/src/modules/ui/theme/hooks/__tests__/useColorScheme.test.tsx --runInBand --verbose` *(fails: Cannot find package '@nx/jest')*

------
https://chatgpt.com/codex/tasks/task_e_68414939c934832fb623c491390c3430