### PR TITLE
Fix workflow diagram step opening logic

### DIFF
--- a/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowRunDiagramCanvasEffect.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowRunDiagramCanvasEffect.tsx
@@ -60,6 +60,15 @@ export const WorkflowRunDiagramCanvasEffect = () => {
           return;
         }
 
+        const currentSelectedNode = getSnapshotValue(
+          snapshot,
+          workflowSelectedNodeState,
+        );
+
+        if (currentSelectedNode === selectedNode.id) {
+          return;
+        }
+
         set(workflowSelectedNodeState, selectedNode.id);
 
         const selectedNodeData = selectedNode.data;

--- a/packages/twenty-front/src/modules/workflow/workflow-diagram/hooks/useHandleWorkflowRunDiagramCanvasInit.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-diagram/hooks/useHandleWorkflowRunDiagramCanvasInit.ts
@@ -5,7 +5,6 @@ import { useRecoilComponentCallbackStateV2 } from '@/ui/utilities/state/componen
 import { useWorkflowRunIdOrThrow } from '@/workflow/hooks/useWorkflowRunIdOrThrow';
 import { workflowVisualizerWorkflowIdComponentState } from '@/workflow/states/workflowVisualizerWorkflowIdComponentState';
 import { workflowDiagramStatusComponentState } from '@/workflow/workflow-diagram/states/workflowDiagramStatusComponentState';
-import { workflowRunDiagramAutomaticallyOpenedStepsComponentState } from '@/workflow/workflow-diagram/states/workflowRunDiagramAutomaticallyOpenedStepsComponentState';
 import { workflowRunStepToOpenByDefaultComponentState } from '@/workflow/workflow-diagram/states/workflowRunStepToOpenByDefaultComponentState';
 import { workflowSelectedNodeComponentState } from '@/workflow/workflow-diagram/states/workflowSelectedNodeComponentState';
 import { getWorkflowNodeIconKey } from '@/workflow/workflow-diagram/utils/getWorkflowNodeIconKey';
@@ -34,10 +33,6 @@ export const useHandleWorkflowRunDiagramCanvasInit = () => {
   const workflowSelectedNodeState = useRecoilComponentCallbackStateV2(
     workflowSelectedNodeComponentState,
   );
-  const workflowRunDiagramAutomaticallyOpenedStepsState =
-    useRecoilComponentCallbackStateV2(
-      workflowRunDiagramAutomaticallyOpenedStepsComponentState,
-    );
 
   const handleWorkflowRunDiagramCanvasInit = useRecoilCallback(
     ({ snapshot, set }) =>
@@ -77,30 +72,16 @@ export const useHandleWorkflowRunDiagramCanvasInit = () => {
 
           set(workflowSelectedNodeState, workflowStepToOpenByDefault.id);
 
-          const workflowRunDiagramAutomaticallyOpenedSteps = getSnapshotValue(
-            snapshot,
-            workflowRunDiagramAutomaticallyOpenedStepsState,
-          );
-          const hasStepAlreadyBeenOpenedAutomatically =
-            workflowRunDiagramAutomaticallyOpenedSteps.includes(
-              workflowStepToOpenByDefault.id,
-            );
-
-          // FIXME: This is a workaround to avoid opening a workflow run step twice when going from the side panel to the fullscreen show page.
-          // The step is opened in the `handleSelectionChange` function of `WorkflowRunDiagramCanvasEffect`. I think it shouldn't be opened there but
-          // we should keep opening the step here, in `handleWorkflowRunDiagramCanvasInit`.
-          if (!hasStepAlreadyBeenOpenedAutomatically) {
-            openWorkflowRunViewStepInCommandMenu({
-              workflowId: workflowVisualizerWorkflowId,
-              workflowRunId,
-              title: workflowStepToOpenByDefault.data.name,
-              icon: getIcon(
-                getWorkflowNodeIconKey(workflowStepToOpenByDefault.data),
-              ),
-              workflowSelectedNode: workflowStepToOpenByDefault.id,
-              stepExecutionStatus: workflowStepToOpenByDefault.data.runStatus,
-            });
-          }
+          openWorkflowRunViewStepInCommandMenu({
+            workflowId: workflowVisualizerWorkflowId,
+            workflowRunId,
+            title: workflowStepToOpenByDefault.data.name,
+            icon: getIcon(
+              getWorkflowNodeIconKey(workflowStepToOpenByDefault.data),
+            ),
+            workflowSelectedNode: workflowStepToOpenByDefault.id,
+            stepExecutionStatus: workflowStepToOpenByDefault.data.runStatus,
+          });
 
           set(workflowRunStepToOpenByDefaultState, undefined);
         }
@@ -111,7 +92,6 @@ export const useHandleWorkflowRunDiagramCanvasInit = () => {
       workflowRunStepToOpenByDefaultState,
       workflowVisualizerWorkflowIdState,
       workflowSelectedNodeState,
-      workflowRunDiagramAutomaticallyOpenedStepsState,
       openWorkflowRunViewStepInCommandMenu,
       workflowRunId,
       getIcon,


### PR DESCRIPTION
## Summary
- prevent duplicated step opening by comparing selected nodes
- remove temporary workaround from workflow diagram init

## Testing
- `npx nx lint twenty-front` *(fails: `npm error canceled`)*

------
https://chatgpt.com/codex/tasks/task_e_6841493bb068832fad2e5a451df9328d