### PR TITLE
Add stable identifiers for create step nodes

### DIFF
--- a/packages/twenty-e2e-testing/lib/fixtures/blank-workflow.ts
+++ b/packages/twenty-e2e-testing/lib/fixtures/blank-workflow.ts
@@ -199,7 +199,7 @@ export class WorkflowVisualizerPage {
       .getByTestId(/^rf__node-.+$/)
       .and(this.#page.getByTestId(/^((?!rf__node-trigger).)*$/))
       .and(
-        this.#page.getByTestId(/^((?!rf__node-branch-\d+__create-step).)*$/),
+        this.#page.getByTestId(/^((?!rf__node-branch-\d+__.*__create-step).)*$/),
       );
   }
 

--- a/packages/twenty-front/src/modules/workflow/workflow-diagram/utils/addCreateStepNodes.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-diagram/utils/addCreateStepNodes.ts
@@ -16,9 +16,11 @@ export const addCreateStepNodes = ({ nodes, edges }: WorkflowDiagram) => {
 
   for (const node of nodesWithoutTargets) {
     const newCreateStepNode: WorkflowDiagramNode = {
-      // FIXME: We need a stable id for create step nodes to be able to preserve their selected status.
-      // FIXME: In the future, we'll have conditions and loops. We'll have to set an id to each branch so we can have this stable id.
-      id: 'branch-1__create-step',
+      // We only support a single branch for now, but include it in the id so
+      // that it remains stable when multiple branches are introduced.
+      // Using the parent node id ensures the identifier does not change across
+      // renders, which allows the selection state of the node to persist.
+      id: `branch-1__${node.id}__create-step`,
       type: 'create-step',
       data: {
         nodeType: 'create-step',


### PR DESCRIPTION
## Summary
- generate stable IDs for `create-step` nodes using branch and parent node
- update regex in e2e fixture to match new create step IDs

## Testing
- `npx nx test twenty-front` *(fails: Could not find Nx modules)*

------
https://chatgpt.com/codex/tasks/task_e_6841493cdfec832f83fe924887860fb1