### PR TITLE
Fix escape key handling in form datetime fields

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/form-types/components/FormDateTimeFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/form-types/components/FormDateTimeFieldInput.tsx
@@ -18,7 +18,14 @@ import { useListenClickOutside } from '@/ui/utilities/pointer-event/hooks/useLis
 import { isStandaloneVariableString } from '@/workflow/utils/isStandaloneVariableString';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import { ChangeEvent, KeyboardEvent, useId, useRef, useState } from 'react';
+import {
+  ChangeEvent,
+  KeyboardEvent,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from 'react';
 import { isDefined } from 'twenty-shared/utils';
 import { TEXT_INPUT_STYLE } from 'twenty-ui/theme';
 import { Nullable } from 'twenty-ui/utilities';
@@ -154,6 +161,25 @@ export const FormDateTimeFieldInput = ({
     enabled: displayDatePicker,
   });
 
+  useEffect(() => {
+    if (!displayDatePicker) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        handlePickerEscape();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [displayDatePicker, handlePickerEscape]);
+
   const handlePickerChange = (newDate: Nullable<Date>) => {
     setDraftValue({
       type: 'static',
@@ -229,6 +255,12 @@ export const FormDateTimeFieldInput = ({
   };
 
   const handleInputKeydown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      handlePickerEscape();
+      return;
+    }
+
     if (event.key !== 'Enter') {
       return;
     }

--- a/packages/twenty-front/src/modules/ui/field/input/components/DateInput.tsx
+++ b/packages/twenty-front/src/modules/ui/field/input/components/DateInput.tsx
@@ -75,11 +75,12 @@ export const DateInput = ({
     onEnter(internalValue);
   };
 
-  const handleEscape = () => {
+  const handleEscape = (originalValue: Nullable<Date>) => {
     closeDropdownYearSelect();
     closeDropdownMonthSelect();
 
-    onEscape(internalValue);
+    setInternalValue(originalValue);
+    onEscape(originalValue);
   };
 
   const handleClickOutside = useRecoilCallback(
@@ -107,7 +108,7 @@ export const DateInput = ({
 
   useRegisterInputEvents({
     inputRef: wrapperRef,
-    inputValue: internalValue,
+    inputValue: value,
     onEnter: handleEnter,
     onEscape: handleEscape,
     onClickOutside: handleClickOutside,


### PR DESCRIPTION
## Summary
- handle Escape in `FormDateTimeFieldInput`
- keep previous value when closing `DateInput` via Escape

## Testing
- `npx nx lint twenty-front` *(fails: Need to install nx)*

------
https://chatgpt.com/codex/tasks/task_e_6841493e590c832f828855219e61a8c6